### PR TITLE
Allow checking of unknown formulae

### DIFF
--- a/brew-caveats.rb
+++ b/brew-caveats.rb
@@ -4,9 +4,9 @@ require 'caveats'
 module Homebrew extend self
   def caveats
     raise FormulaUnspecifiedError if ARGV.named.empty?
-    
-    ARGV.formulae.each do |f|
-      puts_caveats f
+
+    ARGV.named.each do |f|
+      puts_caveats Formulary.factory(f) rescue nil
     end
   end
 


### PR DESCRIPTION
Useful if you have formulae installed by `brew-pip` or `brew-gem`.
