### PR TITLE
Add desc to formula

### DIFF
--- a/Formula/brew-caveats.rb
+++ b/Formula/brew-caveats.rb
@@ -2,6 +2,7 @@ require 'formula'
 
 class BrewCaveats < Formula
   url 'git://github.com/rafaelgarrido/homebrew-caveats.git'
+  desc 'Formulae Caveats Shortcut for Homebrew Package Manager'
   homepage 'https://github.com/rafaelgarrido/homebrew-caveats'
   version '0.1.0'
 


### PR DESCRIPTION
This will allow for a nicely formatted output of `brew bundle dump --describe`.

Currently, `homebrew-caveats` is the only formula in my Brewfile without a description.

For example:

```
$ grep 'brew-caveats' Brewfile -C2
# Packer
brew "hashicorp/tap/packer"
brew "rafaelgarrido/caveats/brew-caveats"
# The tfswitch command lets you switch between terraform versions.
brew "warrensbox/tap/tfswitch"
```