### PR TITLE
Fix: Git protocol

### DIFF
--- a/Formula/brew-caveats.rb
+++ b/Formula/brew-caveats.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class BrewCaveats < Formula
-  url 'git://github.com/rafaelgarrido/homebrew-caveats.git'
+  url 'https://github.com/rafaelgarrido/homebrew-caveats.git'
   desc 'Formulae Caveats Shortcut for Homebrew Package Manager'
   homepage 'https://github.com/rafaelgarrido/homebrew-caveats'
   version '0.1.0'


### PR DESCRIPTION
Change `git://` to `https://`

I tried `brew tap rafaelgarrido/homebrew-caveats && brew install brew-caveats` , but I couldn't it.

```
==> Tapping rafaelgarrido/caveats
Cloning into '/opt/homebrew/Library/Taps/rafaelgarrido/homebrew-caveats'...
remote: Enumerating objects: 91, done.
remote: Counting objects: 100% (13/13), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 91 (delta 2), reused 6 (delta 0), pack-reused 78
Receiving objects: 100% (91/91), 14.33 KiB | 2.39 MiB/s, done.
Resolving deltas: 100% (32/32), done.
Tapped 1 command and 1 formula (16 files, 27.6KB).
==> Cloning git://github.com/rafaelgarrido/homebrew-caveats.git
Updating /Users/user/Library/Caches/Homebrew/brew-caveats--git
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Error: brew-caveats: Failed to download resource "brew-caveats"
Failure while executing; `git fetch origin` exited with 128. Here's the output:
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```